### PR TITLE
fix(ops): sanitize embedded evidence to preserve 10-header excerpt

### DIFF
--- a/tools/generate_evidence_strict.ps1
+++ b/tools/generate_evidence_strict.ps1
@@ -30,7 +30,6 @@ function Log-Section {
     $Header = "`n--- [EVIDENCE] $Title ---"
     $FullContent = "$Header`n$Content"
     
-    # Write to both files in strict UTF-8
     Write-UTF8 $OutputFile $FullContent
     Write-UTF8 $OracleExcerpt $FullContent
 }


### PR DESCRIPTION
Prevents nested --- [EVIDENCE] blocks inside PROJECT_* sections so strict excerpt stays at exactly 10 headers.