### PR TITLE
GOVERNANCE-004: Add GitHub Issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,28 @@
+﻿---
+name: Bug Report
+about: Report a bug in TravelKit
+title: "[Bug] "
+labels: "status:backlog,type:design,priority:p1"
+assignees: ""
+---
+
+## Description
+- What happened?
+
+## Steps to Reproduce
+1.
+2.
+3.
+
+## Expected
+- What you expected to happen.
+
+## Actual
+- What actually happened.
+
+## Acceptance Criteria (PASS/FAIL)
+- [ ] PASS: (define measurable outcome)
+- [ ] PASS: (define measurable outcome)
+
+## Security / Privacy
+- [ ] I confirm this issue contains **NO secrets/tokens/API keys/passwords/PII**.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,24 @@
+﻿---
+name: Feature Request
+about: Propose a new feature or improvement for TravelKit
+title: "[Feature] "
+labels: "status:backlog,type:design,priority:p1"
+assignees: ""
+---
+
+## Problem / Motivation
+- What problem are we solving?
+
+## Proposed Solution
+- What should we build?
+
+## Scope
+- In scope:
+- Out of scope:
+
+## Acceptance Criteria (PASS/FAIL)
+- [ ] PASS: (define measurable outcome)
+- [ ] PASS: (define measurable outcome)
+
+## Security / Privacy
+- [ ] I confirm this issue contains **NO secrets/tokens/API keys/passwords/PII**.


### PR DESCRIPTION
Closes #19

## Summary
- Add bug report & feature request templates with mandatory AC and no-secrets warning.